### PR TITLE
Use SecureRandom

### DIFF
--- a/lib/random_password_generator.rb
+++ b/lib/random_password_generator.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module RandomPasswordGenerator
   # Generates a random password
   # Arguments:
@@ -20,6 +22,6 @@ module RandomPasswordGenerator
     # Skip characters that are unsafe for urls
     chars -= %w($ & + , / : \; = ? @ < > # % { } | ^ ~ [ ] `) if options[:skip_url_unsafe]
 
-    (1..length).collect{chars[rand(chars.size)]}.join
+    (1..length).collect{chars[SecureRandom.random_number(chars.size)]}.join
   end
 end


### PR DESCRIPTION
The rand() method uses the same seed every time, which opens up the possibility of guessing the seed, and therefore the generated passwords. Use SecureRandom instead.